### PR TITLE
Fix package extension dropping as items when loading a world connected to a secured AE system

### DIFF
--- a/src/main/java/thelm/packagedauto/integration/appeng/networking/HostHelperTile.java
+++ b/src/main/java/thelm/packagedauto/integration/appeng/networking/HostHelperTile.java
@@ -14,6 +14,7 @@ public class HostHelperTile<TILE extends TileBase & IGridHost & IActionHost> {
 	public GridBlockTileBase<TILE> gridBlock;
 	public MachineSource source;
 	public IGridNode gridNode;
+	private NBTTagCompound data = null;
 
 	public HostHelperTile(TILE tile) {
 		this.tile = tile;
@@ -24,7 +25,7 @@ public class HostHelperTile<TILE extends TileBase & IGridHost & IActionHost> {
 	public IGridNode getNode() {
 		if(gridNode == null && tile.hasWorld() && !tile.getWorld().isRemote) {
 			gridNode = AEApi.instance().grid().createGridNode(gridBlock);
-			gridNode.setPlayerID(tile.getPlacerID());
+			this.readFromNBT( this.data );
 			gridNode.updateState();
 		}
 		return gridNode;
@@ -41,8 +42,12 @@ public class HostHelperTile<TILE extends TileBase & IGridHost & IActionHost> {
 	}
 
 	public void readFromNBT(NBTTagCompound nbt) {
-		if(tile.hasWorld() && nbt.hasKey("Node")) {
-			getNode().loadFromNBT("Node", nbt);
+		this.data = nbt;
+		if (tile.hasWorld() && data != null && data.hasKey("Node")) {
+			getNode().loadFromNBT("Node", data);
+			data = null;
+		} else if (this.gridNode != null && this.tile.getPlacerID() != -1) {
+			this.gridNode.setPlayerID(this.tile.getPlacerID());
 		}
 	}
 

--- a/src/main/java/thelm/packagedauto/tile/TilePackager.java
+++ b/src/main/java/thelm/packagedauto/tile/TilePackager.java
@@ -80,7 +80,12 @@ public class TilePackager extends TileBase implements ITickable, IGridHost, IAct
 	protected String getLocalizedName() {
 		return I18n.translateToLocal("tile.packagedauto.packager.name");
 	}
-
+	
+	@Override
+	public void onLoad() {
+		updatePowered();
+	}
+	
 	@Override
 	public void update() {
 		if(!world.isRemote) {

--- a/src/main/java/thelm/packagedauto/tile/TilePackagerExtension.java
+++ b/src/main/java/thelm/packagedauto/tile/TilePackagerExtension.java
@@ -85,7 +85,7 @@ public class TilePackagerExtension extends TileBase implements ITickable, IGridH
 
 	@Override
 	public void onLoad() {
-		updatePatternList();
+		updatePowered();
 	}
 
 	@Override


### PR DESCRIPTION
 the package extension calls updatePatternList on the onLoad method, which initialises a grid without the data saved in the NBT, leading to a securitybreak call.
updatePatternList is already called on the NBT read method.
 the unpackager has a call for updatePower on the same method, that was missing on the packager.