### PR TITLE
Make AE system learn Packager recipes on world load

### DIFF
--- a/src/main/java/thelm/packagedauto/integration/appeng/tile/AEPackagerTile.java
+++ b/src/main/java/thelm/packagedauto/integration/appeng/tile/AEPackagerTile.java
@@ -193,6 +193,8 @@ public class AEPackagerTile extends PackagerTile implements IGridHost, IActionHo
 		if(world != null && nbt.contains("Node")) {
 			getActionableNode().loadFromNBT("Node", nbt);
 		}
+		// tell the AE system about any installed recipes
+		postPatternChange();
 	}
 
 	@Override


### PR DESCRIPTION
Untested as I was not able to compile due to:

```
C:\Users\zolle\Documents\GitHub\PackagedAuto\src\main\java\thelm\packagedauto\integration\jei\RecipeLayoutWrapper.java:46: error: incompatible types: inference variable T has incompatible equality constraints V,CAP#1
		return Maps.transformValues(recipeLayout.getIngredientsGroup(PackagedAutoJEIPlugin.jeiRuntime.getIngredientManager().getIngredientType(ingredientClass)).getGuiIngredients(), GuiIngredientWrapper::new);
		                           ^
  where T,V are type-variables:
    T extends Object declared in class GuiIngredientWrapper
    V extends Object declared in method <V>getIngredients(Class<? extends V>)
  where CAP#1 is a fresh type-variable:
    CAP#1 extends V from capture of ? extends V
```